### PR TITLE
Added seed data for Tags and CharityTags, adjusted appsetting.json to include Brian and Max's secrets. CHAIRTY TAGS

### DIFF
--- a/GiveHub/Data/CharityTagData.cs
+++ b/GiveHub/Data/CharityTagData.cs
@@ -1,0 +1,15 @@
+using GiveHub.Models;
+
+namespace GiveHub.Data
+{
+  public class CharityTagData
+  {
+    public static List<CharityTag> CharityTags = new()
+    {
+        new CharityTag() { CharityId = 1, TagId = 1 },
+        new CharityTag() { CharityId = 1, TagId = 5 },
+        new CharityTag() { CharityId = 2, TagId = 2 },
+        new CharityTag() { CharityId = 3, TagId = 3 }
+    };
+  }
+}

--- a/GiveHub/Data/GiveHubDbContext.cs
+++ b/GiveHub/Data/GiveHubDbContext.cs
@@ -8,14 +8,30 @@ namespace GiveHub.Data
     public DbSet<Charity> Charities { get; set; }
     public DbSet<Event> Events { get; set; }
     public DbSet<Tag> Tags { get; set; }
+    public DbSet<CharityTag> CharityTags { get; set; }
 
     public GiveHubDbContext(DbContextOptions<GiveHubDbContext> context) : base(context) { }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+
+      modelBuilder.Entity<CharityTag>()
+      .HasKey(ct => new { ct.CharityId, ct.TagId });
+
+      modelBuilder.Entity<CharityTag>()
+      .HasOne(ct => ct.Charity)
+      .WithMany(c => c.CharityTags)
+      .HasForeignKey(ct => ct.CharityId);
+
+      modelBuilder.Entity<CharityTag>()
+      .HasOne(ct => ct.Tag)
+      .WithMany(t => t.CharityTags)
+      .HasForeignKey(ct => ct.TagId);
+
       modelBuilder.Entity<Charity>().HasData(CharityData.Charities);
       modelBuilder.Entity<Event>().HasData(EventData.Events);
-      // modelBuilder.Entity<Tag>().HasData(TagData.Tag);
+      modelBuilder.Entity<Tag>().HasData(TagData.Tags);
+      modelBuilder.Entity<CharityTag>().HasData(CharityTagData.CharityTags);
     }
   }
 }

--- a/GiveHub/Data/TagData.cs
+++ b/GiveHub/Data/TagData.cs
@@ -11,6 +11,11 @@ namespace GiveHub.Data
       // example
 
       // new() { Id = 1, FirstName = "Lena", LastName = "Marquez", Email = "lena.marquez@example.com", Image = "https://example.com/images/lena.jpg", Favorite = true, UserId = 1 },
+      new Tag() { Id = 1, Name = "Education" },
+      new Tag() { Id = 2, Name = "Environment" },
+      new Tag() { Id = 3, Name = "Food Security" },
+      new Tag() { Id = 4, Name = "Healthcare" },
+      new Tag() { Id = 5, Name = "Youth Empowerment" }
     };
   }
 }

--- a/GiveHub/Models/CharityData.cs
+++ b/GiveHub/Models/CharityData.cs
@@ -40,7 +40,7 @@ namespace GiveHub.Models
     public int Stars { get; set; }
 
     // Navigation properties
-    public List<Tag>? Tags { get; set; }
+    public List<CharityTag> CharityTags { get; set; }
 
     public List<Event>? Events { get; set; }
   }

--- a/GiveHub/Models/CharityTag.cs
+++ b/GiveHub/Models/CharityTag.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace GiveHub.Models
+{
+    public class CharityTag
+    {
+        public int CharityId { get; set; }
+        [Required]
+        public Charity Charity { get; set; }
+        public int TagId { get; set; }
+        [Required]
+        public Tag Tag { get; set; }
+    }
+}

--- a/GiveHub/Models/TagData.cs
+++ b/GiveHub/Models/TagData.cs
@@ -10,5 +10,6 @@ namespace GiveHub.Models
 
     [Required]
     public string Name { get; set; }
+    public List<CharityTag> CharityTags { get; set; }
   }
 }

--- a/GiveHub/Repositories/GiveHubCharityRepository.cs
+++ b/GiveHub/Repositories/GiveHubCharityRepository.cs
@@ -32,17 +32,26 @@ namespace GiveHub.Repositories
 
     public async Task<List<Charity>> GetAllCharitiesAsync()
     {
-      return await _context.Charities.ToListAsync();
+    return await _context.Charities             // load the related Events
+        .Include(c => c.CharityTags)                // load the join entities…
+          .ThenInclude(ct => ct.Tag)               // …and then the Tag on each join
+        .ToListAsync();
     }
 
     public async Task<Charity> GetCharityByIdAsync(int id)
     {
-      return await _context.Charities.FindAsync(id);
+        return await _context.Charities
+        .Include(c => c.CharityTags)              // load the join‐entities
+            .ThenInclude(ct => ct.Tag)            // and then each Tag
+        .FirstOrDefaultAsync(c => c.Id == id);    // filter by your id
     }
     
     public async Task<Charity> GetCharityByUidAsync(string uid)
     {
-      return await _context.Charities.FirstOrDefaultAsync(c => c.UserUid == uid);
+      return await _context.Charities
+        .Include(c => c.CharityTags)                // load the join entities…
+        .ThenInclude(ct => ct.Tag)               // …and then the Tag on each join
+        .FirstOrDefaultAsync(c => c.UserUid == uid);
     }
     
     public async Task<Charity> CreateCharityAsync(Charity charity)

--- a/Migrations/20250416232428_CharityTags.Designer.cs
+++ b/Migrations/20250416232428_CharityTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416232428_CharityTags")]
+    partial class CharityTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -202,29 +205,7 @@ namespace GiveHub.Migrations
 
                     b.HasIndex("TagId");
 
-                    b.ToTable("CharityTags");
-
-                    b.HasData(
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 1
-                        },
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 5
-                        },
-                        new
-                        {
-                            CharityId = 2,
-                            TagId = 2
-                        },
-                        new
-                        {
-                            CharityId = 3,
-                            TagId = 3
-                        });
+                    b.ToTable("CharityTag");
                 });
 
             modelBuilder.Entity("GiveHub.Models.Event", b =>
@@ -394,33 +375,6 @@ namespace GiveHub.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Tags");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            Name = "Education"
-                        },
-                        new
-                        {
-                            Id = 2,
-                            Name = "Environment"
-                        },
-                        new
-                        {
-                            Id = 3,
-                            Name = "Food Security"
-                        },
-                        new
-                        {
-                            Id = 4,
-                            Name = "Healthcare"
-                        },
-                        new
-                        {
-                            Id = 5,
-                            Name = "Youth Empowerment"
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.CharityTag", b =>

--- a/Migrations/20250416232428_CharityTags.cs
+++ b/Migrations/20250416232428_CharityTags.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class CharityTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tags_Charities_CharityId",
+                table: "Tags");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tags_CharityId",
+                table: "Tags");
+
+            migrationBuilder.DropColumn(
+                name: "CharityId",
+                table: "Tags");
+
+            migrationBuilder.CreateTable(
+                name: "CharityTag",
+                columns: table => new
+                {
+                    CharityId = table.Column<int>(type: "integer", nullable: false),
+                    TagId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CharityTag", x => new { x.CharityId, x.TagId });
+                    table.ForeignKey(
+                        name: "FK_CharityTag_Charities_CharityId",
+                        column: x => x.CharityId,
+                        principalTable: "Charities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CharityTag_Tags_TagId",
+                        column: x => x.TagId,
+                        principalTable: "Tags",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CharityTag_TagId",
+                table: "CharityTag",
+                column: "TagId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CharityTag");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CharityId",
+                table: "Tags",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tags_CharityId",
+                table: "Tags",
+                column: "CharityId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tags_Charities_CharityId",
+                table: "Tags",
+                column: "CharityId",
+                principalTable: "Charities",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Migrations/20250416233337_CharityTags2.Designer.cs
+++ b/Migrations/20250416233337_CharityTags2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416233337_CharityTags2")]
+    partial class CharityTags2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -202,29 +205,7 @@ namespace GiveHub.Migrations
 
                     b.HasIndex("TagId");
 
-                    b.ToTable("CharityTags");
-
-                    b.HasData(
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 1
-                        },
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 5
-                        },
-                        new
-                        {
-                            CharityId = 2,
-                            TagId = 2
-                        },
-                        new
-                        {
-                            CharityId = 3,
-                            TagId = 3
-                        });
+                    b.ToTable("CharityTag");
                 });
 
             modelBuilder.Entity("GiveHub.Models.Event", b =>
@@ -394,33 +375,6 @@ namespace GiveHub.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Tags");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            Name = "Education"
-                        },
-                        new
-                        {
-                            Id = 2,
-                            Name = "Environment"
-                        },
-                        new
-                        {
-                            Id = 3,
-                            Name = "Food Security"
-                        },
-                        new
-                        {
-                            Id = 4,
-                            Name = "Healthcare"
-                        },
-                        new
-                        {
-                            Id = 5,
-                            Name = "Youth Empowerment"
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.CharityTag", b =>

--- a/Migrations/20250416233337_CharityTags2.cs
+++ b/Migrations/20250416233337_CharityTags2.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class CharityTags2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Migrations/20250416233523_CharityTags3.Designer.cs
+++ b/Migrations/20250416233523_CharityTags3.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416233523_CharityTags3")]
+    partial class CharityTags3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -203,28 +206,6 @@ namespace GiveHub.Migrations
                     b.HasIndex("TagId");
 
                     b.ToTable("CharityTags");
-
-                    b.HasData(
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 1
-                        },
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 5
-                        },
-                        new
-                        {
-                            CharityId = 2,
-                            TagId = 2
-                        },
-                        new
-                        {
-                            CharityId = 3,
-                            TagId = 3
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.Event", b =>
@@ -394,33 +375,6 @@ namespace GiveHub.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Tags");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            Name = "Education"
-                        },
-                        new
-                        {
-                            Id = 2,
-                            Name = "Environment"
-                        },
-                        new
-                        {
-                            Id = 3,
-                            Name = "Food Security"
-                        },
-                        new
-                        {
-                            Id = 4,
-                            Name = "Healthcare"
-                        },
-                        new
-                        {
-                            Id = 5,
-                            Name = "Youth Empowerment"
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.CharityTag", b =>

--- a/Migrations/20250416233523_CharityTags3.cs
+++ b/Migrations/20250416233523_CharityTags3.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class CharityTags3 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CharityTag_Charities_CharityId",
+                table: "CharityTag");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CharityTag_Tags_TagId",
+                table: "CharityTag");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CharityTag",
+                table: "CharityTag");
+
+            migrationBuilder.RenameTable(
+                name: "CharityTag",
+                newName: "CharityTags");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CharityTag_TagId",
+                table: "CharityTags",
+                newName: "IX_CharityTags_TagId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CharityTags",
+                table: "CharityTags",
+                columns: new[] { "CharityId", "TagId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CharityTags_Charities_CharityId",
+                table: "CharityTags",
+                column: "CharityId",
+                principalTable: "Charities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CharityTags_Tags_TagId",
+                table: "CharityTags",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CharityTags_Charities_CharityId",
+                table: "CharityTags");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CharityTags_Tags_TagId",
+                table: "CharityTags");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CharityTags",
+                table: "CharityTags");
+
+            migrationBuilder.RenameTable(
+                name: "CharityTags",
+                newName: "CharityTag");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CharityTags_TagId",
+                table: "CharityTag",
+                newName: "IX_CharityTag_TagId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CharityTag",
+                table: "CharityTag",
+                columns: new[] { "CharityId", "TagId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CharityTag_Charities_CharityId",
+                table: "CharityTag",
+                column: "CharityId",
+                principalTable: "Charities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CharityTag_Tags_TagId",
+                table: "CharityTag",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Migrations/20250416234051_CharityTags4.Designer.cs
+++ b/Migrations/20250416234051_CharityTags4.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416234051_CharityTags4")]
+    partial class CharityTags4
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -203,28 +206,6 @@ namespace GiveHub.Migrations
                     b.HasIndex("TagId");
 
                     b.ToTable("CharityTags");
-
-                    b.HasData(
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 1
-                        },
-                        new
-                        {
-                            CharityId = 1,
-                            TagId = 5
-                        },
-                        new
-                        {
-                            CharityId = 2,
-                            TagId = 2
-                        },
-                        new
-                        {
-                            CharityId = 3,
-                            TagId = 3
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.Event", b =>
@@ -394,33 +375,6 @@ namespace GiveHub.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Tags");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            Name = "Education"
-                        },
-                        new
-                        {
-                            Id = 2,
-                            Name = "Environment"
-                        },
-                        new
-                        {
-                            Id = 3,
-                            Name = "Food Security"
-                        },
-                        new
-                        {
-                            Id = 4,
-                            Name = "Healthcare"
-                        },
-                        new
-                        {
-                            Id = 5,
-                            Name = "Youth Empowerment"
-                        });
                 });
 
             modelBuilder.Entity("GiveHub.Models.CharityTag", b =>

--- a/Migrations/20250416234051_CharityTags4.cs
+++ b/Migrations/20250416234051_CharityTags4.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class CharityTags4 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Migrations/20250416234801_CharityTags5.Designer.cs
+++ b/Migrations/20250416234801_CharityTags5.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416234801_CharityTags5")]
+    partial class CharityTags5
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250416234801_CharityTags5.cs
+++ b/Migrations/20250416234801_CharityTags5.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class CharityTags5 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Tags",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Education" },
+                    { 2, "Environment" },
+                    { 3, "Food Security" },
+                    { 4, "Healthcare" },
+                    { 5, "Youth Empowerment" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "CharityTags",
+                columns: new[] { "CharityId", "TagId" },
+                values: new object[,]
+                {
+                    { 1, 1 },
+                    { 1, 5 },
+                    { 2, 2 },
+                    { 3, 3 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "CharityTags",
+                keyColumns: new[] { "CharityId", "TagId" },
+                keyValues: new object[] { 1, 1 });
+
+            migrationBuilder.DeleteData(
+                table: "CharityTags",
+                keyColumns: new[] { "CharityId", "TagId" },
+                keyValues: new object[] { 1, 5 });
+
+            migrationBuilder.DeleteData(
+                table: "CharityTags",
+                keyColumns: new[] { "CharityId", "TagId" },
+                keyValues: new object[] { 2, 2 });
+
+            migrationBuilder.DeleteData(
+                table: "CharityTags",
+                keyColumns: new[] { "CharityId", "TagId" },
+                keyValues: new object[] { 3, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 5);
+        }
+    }
+}

--- a/Migrations/20250417000406_TestMigration.Designer.cs
+++ b/Migrations/20250417000406_TestMigration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GiveHub.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GiveHub.Migrations
 {
     [DbContext(typeof(GiveHubDbContext))]
-    partial class GiveHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250417000406_TestMigration")]
+    partial class TestMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250417000406_TestMigration.cs
+++ b/Migrations/20250417000406_TestMigration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GiveHub.Migrations
+{
+    /// <inheritdoc />
+    public partial class TestMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,9 @@ AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
 // ✅ Configure EF Core to use Npgsql with the connection string from appsettings.json or user secrets
 builder.Services.AddDbContext<GiveHubDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("MaxDb")));
+
+builder.Services.AddDbContext<GiveHubDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("BrianDb")));
 
 // ✅ Set the JSON serializer to avoid circular reference issues

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "BrianDb": "Host=localhost;Port=5432;Database=GiveHub;Username=postgres;Password=Haydayhunt45"
+    "BrianDb": "Host=localhost;Port=5432;Database=GiveHub;Username=postgres;Password=Haydayhunt45",
+    "MaxDb": "Host=localhost;Port=5432;Database=givehub;Username=postgres;Password=1292"
   }
 }


### PR DESCRIPTION
Seed Tag and CharityTag Data; Update AppSettings for Multiple ConnectionStrings  

## Description

Added initial seed data for the new `Tag` and `CharityTag` entities so that reusable tags and their mappings to charities are automatically populated on database creation. Also updated the `appsettings.json` to include both **MaxDb** and **BrianDb** connection strings for local development.

- Created **TagData** with 5 predefined tags.  
- Created **CharityTagData** with example mappings between charities and tags.  
- Applied `.HasData(...)` calls in `OnModelCreating` for `Tag` and `CharityTag`.  
- Updated `appsettings.json` to include `"MaxDb"` and `"BrianDb"` under `"ConnectionStrings"`.

## Related Issue

N/A – this work supports the many-to-many tagging feature described in the design doc.

## Motivation and Context

We need a set of reusable tags that can be assigned to charities at creation time, and the database must be seeded with those tags and their associations. Additionally, team members Max and Brian each need their own connection string for local testing without conflicts.

## How Can This Be Tested?

1. Pull down this branch and update your local Postgres credentials in `appsettings.json`.  
2. Run:
   ```bash
   dotnet ef migrations add SeedTagsAndCharityTags
   dotnet ef database update