### PR TITLE
Adjusted GetCharityByUid call to hold a list of charities instead of a singular charity

### DIFF
--- a/GiveHub/Endpoints/CharityEndpoints.cs
+++ b/GiveHub/Endpoints/CharityEndpoints.cs
@@ -40,7 +40,7 @@ namespace GiveHub.Endpoint
       })
       .WithName("GetCharityByUid")
       .WithOpenApi()
-      .Produces<Charity>(StatusCodes.Status200OK);
+      .Produces<List<Charity>>(StatusCodes.Status200OK);
       
       group.MapPost("/", async (Charity charity, IGiveHubCharityService giveHubCharityService) =>
       {

--- a/GiveHub/Interfaces/IGiveHubCharityRepository.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityRepository.cs
@@ -12,9 +12,10 @@ namespace GiveHub.Interfaces
     // seed categories
     Task<List<Charity>> GetAllCharitiesAsync();
     Task<Charity?> GetCharityByIdAsync(int id);
-    Task<Charity?> GetCharityByUidAsync(string uid);
+    Task<List<Charity?>> GetCharityByUidAsync(string uid);
     Task<Charity> CreateCharityAsync(Charity charity);
     Task<Charity> UpdateCharityAsync(int id, Charity charity);
     Task<Charity> DeleteCharityAsync(int id);
+    
   }
 }

--- a/GiveHub/Interfaces/IGiveHubCharityService.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityService.cs
@@ -12,7 +12,7 @@ namespace GiveHub.Interfaces
     // seed categories
     Task<List<Charity>> GetAllCharitiesAsync();
     Task<Charity?> GetCharityByIdAsync(int id);
-    Task<Charity?> GetCharityByUidAsync(string uid);
+    Task<List<Charity?>> GetCharityByUidAsync(string uid);
     Task<Charity> CreateCharityAsync(Charity charity);
     Task<Charity> UpdateCharityAsync(int id, Charity charity);
     Task<Charity> DeleteCharityAsync(int id);

--- a/GiveHub/Repositories/GiveHubCharityRepository.cs
+++ b/GiveHub/Repositories/GiveHubCharityRepository.cs
@@ -39,13 +39,14 @@ namespace GiveHub.Repositories
       .FirstOrDefaultAsync(c => c.Id == id);
     }
 
-    public async Task<Charity?> GetCharityByUidAsync(string uid)
+    public async Task<List<Charity?>> GetCharityByUidAsync(string uid)
     {
       return await _context.Charities
+      .Where(c => c.UserUid == uid)
         .Include(e => e.Events)
         .Include(c => c.CharityTags)
         .ThenInclude(ct => ct.Tag)
-        .FirstOrDefaultAsync(c => c.UserUid == uid);
+        .ToListAsync();
     }
 
     public async Task<Charity> CreateCharityAsync(Charity charity)

--- a/GiveHub/Services/GiveHubCharityService.cs
+++ b/GiveHub/Services/GiveHubCharityService.cs
@@ -44,7 +44,7 @@ namespace GiveHub.Services
       return await _giveHubCharityRepository.GetCharityByIdAsync(id);
     }
 
-    public async Task<Charity?> GetCharityByUidAsync(string uid)
+    public async Task<List<Charity?>> GetCharityByUidAsync(string uid)
     {
       return await _giveHubCharityRepository.GetCharityByUidAsync(uid);
     }


### PR DESCRIPTION
## Description

Refactored the `GetCharityByUidAsync` method to return a list of charities instead of a single charity. This change was made to account for cases where multiple charities may share the same `uid`.

## Related Issue

N/A — Discovered during testing that multiple charities can share the same UID, but only one was being returned due to the API and service setup.

## Motivation and Context

Previously, the API returned only a single `Charity` object for a given UID, which caused incomplete data when multiple charities shared the same UID. This change ensures that all matching charities are retrieved and returned to both Swagger and the frontend.

## How Can This Be Tested?

1. Run the backend server and navigate to Swagger.
2. Use the `/uid/{uid}` route with a UID known to have multiple charities.
3. Confirm that all matching charities are returned in the response.
4. Verify the frontend now displays all relevant charities tied to that UID.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)