### PR TITLE
Added DeleteCharityTag Call

### DIFF
--- a/GiveHub/Endpoints/CharityTagEndpoints.cs
+++ b/GiveHub/Endpoints/CharityTagEndpoints.cs
@@ -29,6 +29,16 @@ namespace GiveHub.Endpoint
     .WithOpenApi()
     .Produces<CharityTag>(StatusCodes.Status201Created);
 
+    group.MapDelete("/{charityId}/{tagId}", async (int charityId, int tagId, IGiveHubCharityTagService giveHubCharityTagService) =>
+    {
+        var success = await giveHubCharityTagService.DeleteCharityTagAsync(charityId, tagId);
+        return success ? Results.NoContent() : Results.NotFound();
+    })
+    .WithName("DeleteCharityTag")
+    .WithOpenApi()
+    .Produces(StatusCodes.Status204NoContent)
+    .Produces(StatusCodes.Status404NotFound);
+
       // group.MapGet("/", async (ISimplyBooksAuthorService simplyBooksAuthorService) =>
       // {
       //   return await simplyBooksAuthorService.GetAllAuthorsAsync();

--- a/GiveHub/Interfaces/IGiveHubCharityTagRepository.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityTagRepository.cs
@@ -14,5 +14,6 @@ namespace GiveHub.Interfaces
     // example
     // Task<List<Author>> GetAllAuthorsAsync();
     Task<CharityTag> CreateCharityTagAsync(CharityTag charityTag);
+    Task<bool> DeleteCharityTagAsync(int charityId, int tagId);
   }
 }

--- a/GiveHub/Interfaces/IGiveHubCharityTagService.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityTagService.cs
@@ -14,5 +14,6 @@ namespace GiveHub.Interfaces
     // example
     // Task<List<Author>> GetAllAuthorsAsync();
     Task<CharityTag> CreateCharityTagAsync(CharityTag charityTag);
+    Task<bool> DeleteCharityTagAsync(int charityId, int tagId);
   }
 }

--- a/GiveHub/Repositories/GiveHubCharityTagRepository.cs
+++ b/GiveHub/Repositories/GiveHubCharityTagRepository.cs
@@ -27,6 +27,16 @@ namespace GiveHub.Repositories
       return charityTag;
     }
 
+    public async Task<bool> DeleteCharityTagAsync(int charityId, int tagId)
+    {
+      var charityTag = await _context.CharityTags.FindAsync(charityId, tagId);
+      if (charityTag == null) return false;
+
+      _context.CharityTags.Remove(charityTag);
+      await _context.SaveChangesAsync();
+      return true;
+    }
+
     
     // seed data
 

--- a/GiveHub/Services/GiveHubCharityTagService.cs
+++ b/GiveHub/Services/GiveHubCharityTagService.cs
@@ -30,6 +30,10 @@ namespace GiveHub.Services
       return await _giveHubCharityTagRepository.CreateCharityTagAsync(charityTag);
     }
 
+    public async Task<bool> DeleteCharityTagAsync(int charityId, int tagId)
+    {
+      return await _giveHubCharityTagRepository.DeleteCharityTagAsync(charityId, tagId);
+    }
 
     // async means that the method is asynchronous.
     // async methods can be awaited using the await keyword.


### PR DESCRIPTION
## Description

Added a new `DELETE` endpoint for `CharityTag` that removes the association between a charity and a tag using their respective IDs. This allows for the removal of specific tag assignments from charities.

## Motivation and Context

This change is required to provide full CRUD functionality for `CharityTag` associations. Being able to remove a tag from a charity enhances flexibility in managing tag relationships and helps keep data accurate and up to date.

## How Can This Be Tested?

- Call the `DELETE /api/charitytags/{charityId}/{tagId}` endpoint in Swagger or Postman.
- Verify that the tag is no longer associated with the charity.
- Ensure that the request returns a `204 No Content` status when successful.
- Test for 404 responses when the combination does not exist.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
