### PR TITLE
Added call to delete all charityTags with the same charityId

### DIFF
--- a/GiveHub/Endpoints/CharityTagEndpoints.cs
+++ b/GiveHub/Endpoints/CharityTagEndpoints.cs
@@ -39,6 +39,15 @@ namespace GiveHub.Endpoint
     .Produces(StatusCodes.Status204NoContent)
     .Produces(StatusCodes.Status404NotFound);
 
+    group.MapDelete("/charity/{charityId}", async (int charityId, IGiveHubCharityTagService giveHubCharityTagService) =>
+    {
+        await giveHubCharityTagService.DeleteAllCharityTagsByCharityIdAsync(charityId);
+        return Results.NoContent();
+    })
+    .WithName("DeleteAllCharityTagsByCharityId")
+    .WithOpenApi()
+    .Produces(StatusCodes.Status204NoContent);
+
       // group.MapGet("/", async (ISimplyBooksAuthorService simplyBooksAuthorService) =>
       // {
       //   return await simplyBooksAuthorService.GetAllAuthorsAsync();

--- a/GiveHub/Interfaces/IGiveHubCharityTagRepository.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityTagRepository.cs
@@ -15,5 +15,6 @@ namespace GiveHub.Interfaces
     // Task<List<Author>> GetAllAuthorsAsync();
     Task<CharityTag> CreateCharityTagAsync(CharityTag charityTag);
     Task<bool> DeleteCharityTagAsync(int charityId, int tagId);
+    Task DeleteAllCharityTagsByCharityIdAsync(int charityId);
   }
 }

--- a/GiveHub/Interfaces/IGiveHubCharityTagService.cs
+++ b/GiveHub/Interfaces/IGiveHubCharityTagService.cs
@@ -15,5 +15,7 @@ namespace GiveHub.Interfaces
     // Task<List<Author>> GetAllAuthorsAsync();
     Task<CharityTag> CreateCharityTagAsync(CharityTag charityTag);
     Task<bool> DeleteCharityTagAsync(int charityId, int tagId);
+    Task DeleteAllCharityTagsByCharityIdAsync(int charityId);
+
   }
 }

--- a/GiveHub/Repositories/GiveHubCharityTagRepository.cs
+++ b/GiveHub/Repositories/GiveHubCharityTagRepository.cs
@@ -37,6 +37,16 @@ namespace GiveHub.Repositories
       return true;
     }
 
+    public async Task DeleteAllCharityTagsByCharityIdAsync(int charityId)
+    {
+      var charityTags = await _context.CharityTags
+          .Where(ct => ct.CharityId == charityId)
+          .ToListAsync();
+
+      _context.CharityTags.RemoveRange(charityTags);
+      await _context.SaveChangesAsync();
+    }
+
     
     // seed data
 

--- a/GiveHub/Services/GiveHubCharityTagService.cs
+++ b/GiveHub/Services/GiveHubCharityTagService.cs
@@ -35,6 +35,11 @@ namespace GiveHub.Services
       return await _giveHubCharityTagRepository.DeleteCharityTagAsync(charityId, tagId);
     }
 
+    public async Task DeleteAllCharityTagsByCharityIdAsync(int charityId)
+    {
+      await _giveHubCharityTagRepository.DeleteAllCharityTagsByCharityIdAsync(charityId);
+    }
+
     // async means that the method is asynchronous.
     // async methods can be awaited using the await keyword.
     // async methods return a Task or Task<T>.


### PR DESCRIPTION
## Description

Added a new `DELETE` endpoint that removes **all CharityTag associations** for a specific `CharityId`. This allows bulk deletion of tag relationships when, for example, a charity is being reset or cleaned up.

## Motivation and Context

This change is required to simplify the management of `CharityTag` relationships. When removing or updating a charity, having the ability to delete all its associated tags at once ensures data consistency and minimizes manual cleanup.

## How Can This Be Tested?

- Call the `DELETE /api/charitytags/charity/{charityId}` endpoint using Swagger or Postman.
- Verify that all `CharityTag` records with the specified `charityId` are removed.
- Confirm a `204 No Content` status code is returned when successful.
- Attempt the call with a non-existent `charityId` to verify no crash or unhandled error occurs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
