### PR TITLE
Removed duplicate MapQuoteEndpoints in Program.cs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -67,7 +67,6 @@ app.UseCors();
 app.MapCharityEndpoints();
 app.MapEventEndpoints();
 app.MapTagEndpoints();
-app.MapQuoteEndpoints();
 app.MapCharityTagEndpoints();
 app.MapQuoteEndpoints();
 


### PR DESCRIPTION
Description

Removed duplicate MapQuoteEndpoints in Program.cs

## Related Issue

#45 

## Motivation and Context

The duplicate mapping threw an error in Swagger, therefore I had to remove it.

## How Can This Be Tested?

Pull down and test manually

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
